### PR TITLE
Avoid O(N) string allocations in unescapeContent

### DIFF
--- a/src/unescape/index.ts
+++ b/src/unescape/index.ts
@@ -8,63 +8,38 @@
  * @throws {@link Error}
  * This exception is thrown if malformed escaped unicode characters are present.
  */
-export const unescapeContent = (escapedContent: string): string => {
-  let unescapedContent = ''
-  for (
-    let character = escapedContent[0], position = 0;
-    position < escapedContent.length;
-    position++, character = escapedContent[position]
-  ) {
-    if (character === '\\') {
-      const nextCharacter = escapedContent[position + 1]
-
-      switch (nextCharacter) {
-        case 'f': {
-          // Formfeed.
-          unescapedContent += '\f'
-          position++
-          break
-        }
-        case 'n': {
-          // Newline.
-          unescapedContent += '\n'
-          position++
-          break
-        }
-        case 'r': {
-          // Carriage return.
-          unescapedContent += '\r'
-          position++
-          break
-        }
-        case 't': {
-          // Tab.
-          unescapedContent += '\t'
-          position++
-          break
-        }
-        case 'u': {
-          // Unicode character.
-          const codePoint = escapedContent.slice(position + 2, position + 6)
-          if (!/[\da-f]{4}/i.test(codePoint)) {
-            // Code point can only be within Unicode's Multilingual Plane (BMP).
-            throw new Error(`malformed escaped unicode characters '\\u${codePoint}'`)
-          }
-          unescapedContent += String.fromCodePoint(Number.parseInt(codePoint, 16))
-          position += 5
-          break
-        }
-        default: {
-          // Otherwise the escape character is not required.
-          unescapedContent += nextCharacter
-          position++
-        }
+export const unescapeContent = (escapedContent: string): string => escapedContent.replace(
+  /\\[^u]|\\u..../g,
+  function unescapeOne(escapeSequence: string): string {
+    const nextCharacter = escapeSequence.charAt(1)
+    switch (nextCharacter) {
+      case 'f': {
+        // Formfeed.
+        return '\f'
       }
-    } else {
-      // When there is \, simply add the character.
-      unescapedContent += character
+      case 'n': {
+        // Newline.
+        return '\n'
+      }
+      case 'r': {
+        // Carriage return.
+        return '\r'
+      }
+      case 't': {
+        // Tab.
+        return '\t'
+      }
+      case 'u': {
+        // Unicode character.
+        const codePoint = escapeSequence.slice(2, 6)
+        if (!/[\da-f]{4}/i.test(codePoint)) {
+          // Code point can only be within Unicode's Multilingual Plane (BMP).
+          throw new Error(`malformed escaped unicode characters '\\u${codePoint}'`)
+        }
+        return String.fromCodePoint(Number.parseInt(codePoint, 16))
+      }
+      default: {
+        return nextCharacter
+      }
     }
-  }
-
-  return unescapedContent
-}
+  })


### PR DESCRIPTION
I have a file with ≤1000 lines, and the longest line is ≤400 characters long. Unfortunately, I have seen my poor AWS Lambda box time out (10 sec+) while processing this file. Profiling showed `unescapeContent` as the costliest function. None of my strings have escape characters in them, so this function should be able to return very quickly. However, whatever version of Node I'm using is not optimizing out the string concatenation in a tight loop, and this is causing a significant amount of pointless allocations and GC. Using a global `RegExp` allows this function to run very quickly, with a minimum of string concatenations.