### PR TITLE
build: type-check all sub-projects + bump CI Node matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, latest]
+        node-version: [22, 24, latest]
     steps:
       # Checkout
       - name: Checkout
@@ -50,13 +50,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # Node 20 is only used to compile TypeScript → CJS.
+      # Node 24 is only used to compile TypeScript → CJS.
       # The actual test runs inside a Docker container with Node 0.4.0
       # compiled from source (the first stable release with ES5 support).
       - name: Setup node (for compilation only)
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/eslint/package-json-types.d.ts
+++ b/eslint/package-json-types.d.ts
@@ -1,0 +1,47 @@
+/**
+ * Local type override for @package-json/types.
+ *
+ * `@package-json/types@0.0.12` (the version pulled in transitively by
+ * `eslint-plugin-import-x`) has internal contradictions in its d.ts where
+ * optional properties (`node?: string`, `extends?: string`, `main?: string`,
+ * `browser?: string`) are declared alongside `[k: string]: string` index
+ * signatures, producing four TS2411 errors under `strict`.
+ *
+ * The `paths` mapping in tsconfig.json redirects all `@package-json/types`
+ * imports to this file, bypassing the broken upstream. This file exposes
+ * only the symbols that `eslint-plugin-import-x` actually consumes (see
+ * `eslint-plugin-import-x/lib/utils/read-pkg-up.d.ts` and
+ * `eslint-plugin-import-x/lib/rules/no-extraneous-dependencies.d.ts`).
+ *
+ * Upstream status (as of 2026-05-18):
+ * - The bug is fixed in `@package-json/types@0.0.13` via commit 5ff69e72,
+ *   which landed through the package's `src/patch/` mechanism (the proper
+ *   path for changes that need to survive `build:upstream` regeneration).
+ * - `eslint-plugin-import-x` currently pins `^0.0.12`. A bump PR
+ *   (https://github.com/un-ts/eslint-plugin-import-x/pull/478) is open,
+ *   alongside discussions in issues #471, #476, and #477 exploring whether
+ *   to bump the dependency or replace it with an inline `PackageJson` type.
+ *   Either resolution would unblock consumers; the choice is up to the
+ *   maintainers.
+ *
+ * Remove this override (and the `paths` entry in tsconfig.json) once
+ * `eslint-plugin-import-x` ships with `@package-json/types@^0.0.13` or
+ * adopts an inline type.
+ */
+
+declare module '@package-json/types' {
+  export type Dependency = Record<string, string>
+  export type DevDependency = Record<string, string>
+  export type OptionalDependency = Record<string, string>
+  export type PeerDependency = Record<string, string>
+
+  export type PackageJson = {
+    name?: string
+    version?: string
+    dependencies?: Dependency
+    devDependencies?: DevDependency
+    optionalDependencies?: OptionalDependency
+    peerDependencies?: PeerDependency
+    [key: string]: unknown
+  }
+}

--- a/eslint/tsconfig.json
+++ b/eslint/tsconfig.json
@@ -3,8 +3,12 @@
     "rootDir": "..",
     "target": "ESNext",
     "types": ["node"],
-    "module": "NodeNext",
-    "strict": true
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "paths": {
+      "@package-json/types": ["./package-json-types.d.ts"]
+    }
   },
   "include": ["./**/*.ts", "../eslint.config.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   ],
   "scripts": {
     "benchmark": "npx tsx performance/benchmarks/compare.ts",
-    "build": "npm run check-nvm-node-version && npm run prettier-write && npm run eslint-fix && rm -Rf ./dist && tsc && npx tsx src/build-scripts/build.ts && npm run test && npm run size",
+    "build": "npm run check-nvm-node-version && npm run prettier-write && npm run eslint-fix && npm run typecheck && rm -Rf ./dist && tsc && npx tsx src/build-scripts/build.ts && npm run test && npm run size",
     "check-nvm-node-version": "check-node-version --node $(node -p \"'>='+require('fs').readFileSync('.nvmrc','utf-8').trim()\")",
     "depcheck": "depcheck",
     "eslint-fix": "eslint --fix",
@@ -141,7 +141,8 @@
     "size": "npx tsx performance/size/compare.ts",
     "snapshot": "npx tsx performance/snapshots/manage.ts",
     "test": "jest --coverage",
-    "test-node-compat": "docker build --platform linux/amd64 -f tests/node-compat/Dockerfile.node-0.4 ."
+    "test-node-compat": "docker build --platform linux/amd64 -f tests/node-compat/Dockerfile.node-0.4 .",
+    "typecheck": "find . -name tsconfig.json -not -path '*/node_modules/*' -not -path '*/dist/*' -not -path '*/.*/*' -print0 | xargs -0 -n1 -I{} npx tsc --noEmit -p {}"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "10.0.6",


### PR DESCRIPTION
## Summary

- **Type-check all sub-projects in the build pipeline.** Previously only `src/` was type-checked at build time (via `tsc`). Type errors in `eslint/`, `src/build-scripts/`, `tests/`, and `performance/` only surfaced in the IDE. New `typecheck` script auto-discovers every `tsconfig.json` and runs `tsc --noEmit` against each — chained into `build` between `eslint-fix` and `tsc` to fail fast (~13s overhead).
- **Fix two prerequisites uncovered while enabling this.** `eslint/tsconfig.json` switches from `NodeNext` to bundler module resolution (matches how `jiti` actually loads the eslint config). Added a local `@package-json/types` override (via tsconfig `paths`) to work around four TS2411 errors in v0.0.12 — the bug is fixed upstream in v0.0.13 but not yet adopted by `eslint-plugin-import-x` (see PR un-ts/eslint-plugin-import-x#478).
- **CI matrix:** drop Node.js 20 (EOL April 2026), add Node.js 24 (current active LTS).

## Test plan

- [ ] CI passes on Node.js 22, 24, latest
- [ ] `npm run typecheck` exits 0 on a clean tree
- [ ] Reverting the local `@package-json/types` override surfaces 4 TS2411 errors (confirms the workaround is load-bearing)
- [ ] Adding `const x: string = 5` anywhere under `eslint/` causes `npm run build` to fail at the `typecheck` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)